### PR TITLE
Complete EN/PL i18n rollout across client

### DIFF
--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -191,6 +191,10 @@ const resources = {
         statsDaily: 'Daily',
         statsChallenges: 'New Challenges',
         games: {
+          worldTitle: 'Countrydle',
+          usStatesTitle: 'US Statedle',
+          powiatyTitle: 'Powiatdle',
+          wojewodztwaTitle: 'Wojewodztwdle',
           worldDescription: 'Guess the mystery country from across the globe.',
           usStatesDescription: 'Test your knowledge of the 50 United States.',
           powiatyDescription: 'Polish counties (powiaty) challenge for experts.',
@@ -460,6 +464,10 @@ const resources = {
         statsDaily: 'Codziennie',
         statsChallenges: 'Nowe wyzwania',
         games: {
+          worldTitle: 'Countrydle',
+          usStatesTitle: 'US Statedle',
+          powiatyTitle: 'Powiatdle',
+          wojewodztwaTitle: 'Wojewodztwdle',
           worldDescription: 'Odgadnij tajemniczy kraj z calego swiata.',
           usStatesDescription: 'Sprawdz swoja wiedze o 50 stanach USA.',
           powiatyDescription: 'Wyzwanie z polskich powiatow dla ekspertow.',

--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -167,6 +167,7 @@ const resources = {
       },
       tabs: {
         countries: 'Countries',
+        powiaty: 'Powiaty',
         usStates: 'US States',
         wojewodztwa: 'Wojewodztwa',
       },
@@ -440,6 +441,7 @@ const resources = {
       },
       tabs: {
         countries: 'Kraje',
+        powiaty: 'Powiaty',
         usStates: 'Stany USA',
         wojewodztwa: 'Wojewodztwa',
       },

--- a/client/src/pages/ArchivePage.tsx
+++ b/client/src/pages/ArchivePage.tsx
@@ -36,7 +36,7 @@ export default function ArchivePage() {
 
   const tabs = [
     { id: 'country', label: t('tabs.countries'), icon: Globe },
-    { id: 'powiat', label: 'Powiaty', icon: Map },
+    { id: 'powiat', label: t('tabs.powiaty'), icon: Map },
     { id: 'us_state', label: t('tabs.usStates'), icon: Flag },
     { id: 'wojewodztwo', label: t('tabs.wojewodztwa'), icon: MapPin },
   ];

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -18,7 +18,7 @@ export default function HomePage() {
   const games = [
     {
       id: 'world',
-      title: 'Countrydle',
+      title: t('home.games.worldTitle'),
       description: t('home.games.worldDescription'),
       path: '/game',
       icon: <Globe size={32} className="text-blue-500" />,
@@ -27,7 +27,7 @@ export default function HomePage() {
     },
     {
       id: 'us-states',
-      title: 'US Statedle',
+      title: t('home.games.usStatesTitle'),
       description: t('home.games.usStatesDescription'),
       path: '/us-states',
       icon: <MapIcon size={32} className="text-indigo-500" />,
@@ -36,7 +36,7 @@ export default function HomePage() {
     },
     {
       id: 'powiaty',
-      title: 'Powiatdle',
+      title: t('home.games.powiatyTitle'),
       description: t('home.games.powiatyDescription'),
       path: '/powiaty',
       icon: <MapPin size={32} className="text-red-500" />,
@@ -45,7 +45,7 @@ export default function HomePage() {
     },
     {
       id: 'wojewodztwa',
-      title: 'Wojewodztwdle',
+      title: t('home.games.wojewodztwaTitle'),
       description: t('home.games.wojewodztwaDescription'),
       path: '/wojewodztwa',
       icon: <Flag size={32} className="text-green-500" />,

--- a/client/src/pages/LeaderboardPage.tsx
+++ b/client/src/pages/LeaderboardPage.tsx
@@ -34,7 +34,7 @@ export default function LeaderboardPage() {
 
   const tabs = [
     { id: 'country', label: t('tabs.countries'), icon: Globe },
-    { id: 'powiat', label: 'Powiaty', icon: Map },
+    { id: 'powiat', label: t('tabs.powiaty'), icon: Map },
     { id: 'us_state', label: t('tabs.usStates'), icon: Flag },
     { id: 'wojewodztwo', label: t('tabs.wojewodztwa'), icon: MapPin },
   ];

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -77,7 +77,7 @@ export default function ProfilePage() {
   const currentStats = stats[activeTab];
   const modeLabels = {
     countrydle: t('tabs.countries'),
-    powiatdle: 'Powiaty',
+    powiatdle: t('tabs.powiaty'),
     us_statedle: t('tabs.usStates'),
     wojewodztwodle: t('tabs.wojewodztwa'),
   };
@@ -141,7 +141,7 @@ export default function ProfilePage() {
       <div className="flex overflow-x-auto gap-2 mb-6 pb-2">
         {[
           { id: 'countrydle', label: t('tabs.countries') },
-          { id: 'powiatdle', label: 'Powiaty' },
+          { id: 'powiatdle', label: t('tabs.powiaty') },
           { id: 'us_statedle', label: t('tabs.usStates') },
           { id: 'wojewodztwodle', label: t('tabs.wojewodztwa') }
         ].map((tab) => (


### PR DESCRIPTION
## Summary
- add full EN/PL i18n support across shared UI, game pages, home/auth/profile/archive/leaderboard pages, and legal policy pages
- add top-right language selector with browser detection and localStorage persistence
- replace remaining hardcoded labels/placeholders/tooltips in archive/tabs and related shared components

## Validation
- `npm run build` (client) passes
- Vite reports existing env-var warnings for optional runtime variables in `index.html`

## Notes
- this PR includes and supersedes the earlier stacked i18n branch work