### PR TITLE
Add guest gameplay and prevent target spoilers

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ "main" ]
     tags: [ "v*" ]
+  pull_request:
+    branches: [ "main" ]
 
 env:
   # Use GitHub Container Registry by default
@@ -37,6 +39,7 @@ jobs:
           tags: |
             type=ref,event=tag
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest-${{ github.event.pull_request.number }},enable=${{ github.event_name == 'pull_request' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -71,6 +74,7 @@ jobs:
           tags: |
             type=ref,event=tag
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest-${{ github.event.pull_request.number }},enable=${{ github.event_name == 'pull_request' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 
 data/
 postgres_data*/
+postgres_test_data/
 qdrant_data/
 backups/
 

--- a/client/src/components/MapBox.tsx
+++ b/client/src/components/MapBox.tsx
@@ -51,7 +51,7 @@ function MapControls({ correctCountryName, geoJsonData, map }: MapControlsProps)
           <RotateCcw size={16} />
        </button>
        
-       {gameState?.is_game_over && (
+       {gameState?.won && (
          <button
             onClick={(e) => {
                 e.preventDefault();
@@ -72,7 +72,7 @@ function MapController({ correctCountryName, geoJsonData }: { correctCountryName
   const { gameState } = useGameStore();
 
   useEffect(() => {
-    if (gameState?.is_game_over && correctCountryName && geoJsonData) {
+    if (gameState?.won && correctCountryName && geoJsonData) {
       // Find the feature for the correct country
       const correctFeature = geoJsonData.features.find((f: any) => 
         f.properties.SOVEREIGNT.toUpperCase() === correctCountryName.toUpperCase()
@@ -86,7 +86,7 @@ function MapController({ correctCountryName, geoJsonData }: { correctCountryName
         }
       }
     }
-  }, [gameState?.is_game_over, correctCountryName, geoJsonData, map]);
+  }, [gameState?.won, correctCountryName, geoJsonData, map]);
 
   return null;
 }
@@ -139,19 +139,19 @@ export default function MapBox({ correctCountryName, className }: MapBoxProps) {
                  const newStyle = getStyleFromState(
                      feature, 
                      selectedEntityNames, 
-                     gameState?.is_game_over ? correctCountryName || correctEntity?.name : undefined
+                      gameState?.won ? correctCountryName || correctEntity?.name : undefined
                  );
                  layer.setStyle(newStyle);
                  
                  // If game over and correct country, bring to front
                  const countryName = feature.properties.SOVEREIGNT.toUpperCase();
-                 if (correctCountryName && (countryName === correctCountryName.toUpperCase())) {
-                     layer.bringToFront();
-                 }
+                  if (gameState?.won && correctCountryName && (countryName === correctCountryName.toUpperCase())) {
+                      layer.bringToFront();
+                  }
              }
         });
     }
-  }, [selectedEntityNames, gameState?.is_game_over, correctCountryName]);
+  }, [selectedEntityNames, gameState?.won, correctCountryName]);
 
   const onEachFeature = (feature: Feature, layer: L.Layer) => {
     const countryName = feature.properties?.SOVEREIGNT;
@@ -178,7 +178,7 @@ export default function MapBox({ correctCountryName, className }: MapBoxProps) {
         const style = getStyleFromState(
             feature, 
             currentSelected, 
-            correctEntity?.name
+            gameState?.won ? correctEntity?.name : undefined
         );
         l.setStyle(style);
       }

--- a/client/src/components/PowiatyMap.tsx
+++ b/client/src/components/PowiatyMap.tsx
@@ -16,7 +16,7 @@ function MapController({ correctName, geoJsonData }: { correctName?: string, geo
   const { gameState } = usePowiatyGameStore();
 
   useEffect(() => {
-    if (gameState?.is_game_over && correctName && geoJsonData) {
+    if (gameState?.won && correctName && geoJsonData) {
       const correctFeature = geoJsonData.features.find((f: any) => 
         f.properties.nazwa.toUpperCase() === correctName.toUpperCase()
       );
@@ -29,7 +29,7 @@ function MapController({ correctName, geoJsonData }: { correctName?: string, geo
         }
       }
     }
-  }, [gameState?.is_game_over, correctName, geoJsonData, map]);
+  }, [gameState?.won, correctName, geoJsonData, map]);
 
   return null;
 }
@@ -71,7 +71,7 @@ export default function PowiatyMap({ correctPowiatName, className }: PowiatyMapP
       return getStyleFromState(
           feature, 
           selectedEntityNames, 
-          gameState?.is_game_over ? correctEntity?.nazwa : undefined
+          gameState?.won ? correctEntity?.nazwa : undefined
       );
   }
 
@@ -84,17 +84,17 @@ export default function PowiatyMap({ correctPowiatName, className }: PowiatyMapP
                  const newStyle = getStyleFromState(
                      feature, 
                      selectedPowiaty, 
-                     gameState?.is_game_over ? correctPowiatName || correctEntity?.nazwa : undefined
-                 );
+                      gameState?.won ? correctPowiatName || correctEntity?.nazwa : undefined
+                  );
                  layer.setStyle(newStyle);
                  
-                 if (gameState?.is_game_over && (correctPowiatName || correctEntity?.nazwa) && (feature.properties.nazwa.toUpperCase() === (correctPowiatName || correctEntity?.nazwa ).toUpperCase())) {
-                     layer.bringToFront();
-                 }
+                  if (gameState?.won && (correctPowiatName || correctEntity?.nazwa) && (feature.properties.nazwa.toUpperCase() === (correctPowiatName || correctEntity?.nazwa ).toUpperCase())) {
+                      layer.bringToFront();
+                  }
              }
         });
     }
-  }, [selectedPowiaty, gameState?.is_game_over, correctPowiatName]);
+  }, [selectedPowiaty, gameState?.won, correctPowiatName]);
 
   const onEachFeature = (feature: Feature, layer: L.Layer) => {
     const name = feature.properties?.nazwa;
@@ -118,7 +118,7 @@ export default function PowiatyMap({ correctPowiatName, className }: PowiatyMapP
         const style = getStyleFromState(
             feature, 
             currentSelected, 
-            gameState?.is_game_over ? correctEntity?.nazwa : undefined
+            gameState?.won ? correctEntity?.nazwa : undefined
         );
         l.setStyle(style);
       }
@@ -168,7 +168,7 @@ export default function PowiatyMap({ correctPowiatName, className }: PowiatyMapP
           <RotateCcw size={16} />
         </button>
         
-        {gameState?.is_game_over && (
+        {gameState?.won && (
           <button
             onClick={handleZoomToCorrect}
             className="bg-green-600 text-white p-2 rounded shadow-md hover:bg-green-700 transition-colors border border-green-500 w-8 h-8 flex items-center justify-center cursor-pointer"

--- a/client/src/components/USStatesMap.tsx
+++ b/client/src/components/USStatesMap.tsx
@@ -16,7 +16,7 @@ function MapController({ correctName, geoJsonData }: { correctName?: string, geo
   const { gameState } = useUSStatesGameStore();
 
   useEffect(() => {
-    if (gameState?.is_game_over && correctName && geoJsonData) {
+    if (gameState?.won && correctName && geoJsonData) {
       const correctFeature = geoJsonData.features.find((f: any) => 
         f.properties.name.toUpperCase() === correctName.toUpperCase()
       );
@@ -29,7 +29,7 @@ function MapController({ correctName, geoJsonData }: { correctName?: string, geo
         }
       }
     }
-  }, [gameState?.is_game_over, correctName, geoJsonData, map]);
+  }, [gameState?.won, correctName, geoJsonData, map]);
 
   return null;
 }
@@ -71,7 +71,7 @@ export default function USStatesMap({ correctStateName, className }: USStatesMap
       return getStyleFromState(
           feature, 
           selectedEntityNames, 
-          gameState?.is_game_over ? correctEntity?.name : undefined
+          gameState?.won ? correctEntity?.name : undefined
       );
   }
 
@@ -84,17 +84,17 @@ export default function USStatesMap({ correctStateName, className }: USStatesMap
                  const newStyle = getStyleFromState(
                      feature, 
                      selectedEntityNames, 
-                     gameState?.is_game_over ? correctStateName || correctEntity?.name : undefined
-                 );
+                      gameState?.won ? correctStateName || correctEntity?.name : undefined
+                  );
                  layer.setStyle(newStyle);
                  
-                 if (gameState?.is_game_over && (correctStateName || correctEntity?.name) && (feature.properties.name.toUpperCase() === (correctStateName || correctEntity?.name).toUpperCase())) {
-                     layer.bringToFront();
-                 }
+                  if (gameState?.won && (correctStateName || correctEntity?.name) && (feature.properties.name.toUpperCase() === (correctStateName || correctEntity?.name).toUpperCase())) {
+                      layer.bringToFront();
+                  }
              }
         });
     }
-  }, [selectedEntityNames, gameState?.is_game_over, correctStateName]);
+  }, [selectedEntityNames, gameState?.won, correctStateName]);
 
   const onEachFeature = (feature: Feature, layer: L.Layer) => {
     const name = feature.properties?.name;
@@ -118,7 +118,7 @@ export default function USStatesMap({ correctStateName, className }: USStatesMap
         const style = getStyleFromState(
             feature, 
             currentSelected, 
-            gameState?.is_game_over ? correctEntity?.name : undefined
+            gameState?.won ? correctEntity?.name : undefined
         );
         l.setStyle(style);
       }
@@ -167,7 +167,7 @@ export default function USStatesMap({ correctStateName, className }: USStatesMap
           <RotateCcw size={16} />
         </button>
         
-        {gameState?.is_game_over && (
+        {gameState?.won && (
           <button
             onClick={handleZoomToCorrect}
             className="bg-green-600 text-white p-2 rounded shadow-md hover:bg-green-700 transition-colors border border-green-500 w-8 h-8 flex items-center justify-center cursor-pointer"

--- a/client/src/components/WojewodztwaMap.tsx
+++ b/client/src/components/WojewodztwaMap.tsx
@@ -16,7 +16,7 @@ function MapController({ correctName, geoJsonData }: { correctName?: string, geo
   const { gameState } = useWojewodztwaGameStore();
 
   useEffect(() => {
-    if (gameState?.is_game_over && correctName && geoJsonData) {
+    if (gameState?.won && correctName && geoJsonData) {
       const correctFeature = geoJsonData.features.find((f: any) => 
         f.properties.nazwa.toUpperCase() === correctName.toUpperCase()
       );
@@ -29,7 +29,7 @@ function MapController({ correctName, geoJsonData }: { correctName?: string, geo
         }
       }
     }
-  }, [gameState?.is_game_over, correctName, geoJsonData, map]);
+  }, [gameState?.won, correctName, geoJsonData, map]);
 
   return null;
 }
@@ -71,7 +71,7 @@ export default function WojewodztwaMap({ correctWojewodztwoName, className }: Wo
       return getStyleFromState(
           feature, 
           selectedEntityNames, 
-          gameState?.is_game_over ? correctEntity?.nazwa : undefined
+          gameState?.won ? correctEntity?.nazwa : undefined
       );
   }
 
@@ -84,17 +84,17 @@ export default function WojewodztwaMap({ correctWojewodztwoName, className }: Wo
                  const newStyle = getStyleFromState(
                      feature, 
                      selectedEntityNames, 
-                     gameState?.is_game_over ? correctWojewodztwoName || correctEntity?.nazwa : undefined
-                 );
+                      gameState?.won ? correctWojewodztwoName || correctEntity?.nazwa : undefined
+                  );
                  layer.setStyle(newStyle);
                  
-                 if (gameState?.is_game_over && (correctWojewodztwoName || correctEntity?.nazwa) && (feature.properties.nazwa.toUpperCase() === (correctWojewodztwoName || correctEntity?.nazwa).toUpperCase())) {
-                     layer.bringToFront();
-                 }
+                  if (gameState?.won && (correctWojewodztwoName || correctEntity?.nazwa) && (feature.properties.nazwa.toUpperCase() === (correctWojewodztwoName || correctEntity?.nazwa).toUpperCase())) {
+                      layer.bringToFront();
+                  }
              }
         });
     }
-  }, [selectedEntityNames, gameState?.is_game_over, correctWojewodztwoName]);
+  }, [selectedEntityNames, gameState?.won, correctWojewodztwoName]);
 
   const onEachFeature = (feature: Feature, layer: L.Layer) => {
     const name = feature.properties?.nazwa;
@@ -118,7 +118,7 @@ export default function WojewodztwaMap({ correctWojewodztwoName, className }: Wo
         const style = getStyleFromState(
             feature, 
             currentSelected, 
-            gameState?.is_game_over ? correctEntity?.nazwa : undefined
+            gameState?.won ? correctEntity?.nazwa : undefined
         );
         l.setStyle(style);
       }
@@ -130,7 +130,7 @@ export default function WojewodztwaMap({ correctWojewodztwoName, className }: Wo
   };
 
   const handleZoomToCorrect = () => {
-    const targetName = correctWojewodztwoName || correctEntity?.name;
+    const targetName = correctWojewodztwoName || correctEntity?.nazwa;
     
     if (map && targetName && geoJsonData) {
       const correctFeature = geoJsonData.features.find((f: any) => 
@@ -167,7 +167,7 @@ export default function WojewodztwaMap({ correctWojewodztwoName, className }: Wo
           <RotateCcw size={16} />
         </button>
         
-        {gameState?.is_game_over && (
+        {gameState?.won && (
           <button
             onClick={handleZoomToCorrect}
             className="bg-green-600 text-white p-2 rounded shadow-md hover:bg-green-700 transition-colors border border-green-500 w-8 h-8 flex items-center justify-center cursor-pointer"

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1,7 +1,5 @@
 import { useEffect } from 'react';
 import { useGameStore } from '../stores/gameStore';
-import { useAuthStore } from '../stores/authStore';
-import { useNavigate } from 'react-router-dom';
 import QuestionInput from '../components/QuestionInput';
 import History from '../components/History';
 import GuessInput from '../components/GuessInput';
@@ -23,25 +21,14 @@ export default function GamePage() {
     askQuestion, 
     makeGuess 
   } = useGameStore();
-  const { isAuthenticated, isLoading: isAuthLoading } = useAuthStore();
   const { t } = useTranslation();
-  const navigate = useNavigate();
 
   useEffect(() => {
-    if (!isAuthLoading && !isAuthenticated) {
-      navigate('/login');
-    }
-  }, [isAuthenticated, isAuthLoading, navigate]);
+    fetchGameState();
+    fetchCountries();
+  }, [fetchGameState, fetchCountries]);
 
-
-  useEffect(() => {
-    if (isAuthenticated) {
-      fetchGameState();
-      fetchCountries();
-    }
-  }, [isAuthenticated, fetchGameState, fetchCountries]);
-
-  if (isAuthLoading || (!gameState && isLoading)) {
+  if (!gameState && isLoading) {
     return (
       <div className="flex justify-center items-center h-[60vh]">
         <Loader2 className="animate-spin text-blue-500" size={48} />
@@ -91,7 +78,7 @@ export default function GamePage() {
         <div className="w-full lg:w-3/4 flex flex-col p-3 md:p-4 gap-4 lg:overflow-y-auto custom-scrollbar">
             {/* Map */}
             <div className="h-[300px] md:h-[400px] lg:flex-1 lg:mb-16 min-h-[300px] shrink-0 bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden relative shadow-lg">
-                <MapBox correctCountryName={correctCountry?.name} className="h-full" />
+                <MapBox correctCountryName={gameState.won ? correctCountry?.name : undefined} className="h-full" />
             </div>
 
             {/* Game Over Message */}
@@ -105,7 +92,7 @@ export default function GamePage() {
                     ? t('gamePage.wonMessage')
                     : t('gamePage.lostMessage')}
                 </p>
-                 {(correctCountry || guesses.find(g => g.answer)?.guess) && (
+                 {gameState.won && (correctCountry || guesses.find(g => g.answer)?.guess) && (
                     <p className="text-sm md:text-base">{t('gamePage.answer')} <span className="font-bold">{correctCountry?.name || guesses.find(g => g.answer)?.guess}</span></p>
                  )}
               </div>
@@ -221,4 +208,3 @@ export default function GamePage() {
     </div>
   );
 }
-

--- a/client/src/pages/PowiatyGamePage.tsx
+++ b/client/src/pages/PowiatyGamePage.tsx
@@ -1,7 +1,5 @@
 import { useEffect } from 'react';
 import { usePowiatyGameStore } from '../stores/gameStore';
-import { useAuthStore } from '../stores/authStore';
-import { useNavigate } from 'react-router-dom';
 import QuestionInput from '../components/QuestionInput';
 import History from '../components/History';
 import GuessInput from '../components/GuessInput';
@@ -24,25 +22,14 @@ export default function PowiatyGamePage() {
     makeGuess
   } = usePowiatyGameStore();
 
-  const { isAuthenticated, isLoading: isAuthLoading } = useAuthStore();
   const { t } = useTranslation();
-  const navigate = useNavigate();
 
   useEffect(() => {
-    if (!isAuthLoading && !isAuthenticated) {
-      navigate('/login');
-    }
-  }, [isAuthenticated, isAuthLoading, navigate]);
+    fetchGameState();
+    fetchPowiaty();
+  }, [fetchGameState, fetchPowiaty]);
 
-
-  useEffect(() => {
-    if (isAuthenticated) {
-      fetchGameState();
-      fetchPowiaty();
-    }
-  }, [isAuthenticated, fetchGameState, fetchPowiaty]);
-
-  if (isAuthLoading || (!gameState && isLoading)) {
+  if (!gameState && isLoading) {
     return (
       <div className="flex justify-center items-center h-[60vh]">
         <Loader2 className="animate-spin text-blue-500" size={48} />
@@ -97,7 +84,7 @@ export default function PowiatyGamePage() {
 
             <div className="h-[300px] md:h-[400px] lg:flex-1 lg:mb-16 min-h-[300px] shrink-0 bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden relative shadow-lg">
                 <PowiatyMap 
-                    correctPowiatName={correctPowiat?.name}
+                    correctPowiatName={gameState.won ? correctPowiat?.nazwa : undefined}
                     className="h-full"
                 />
             </div>
@@ -113,7 +100,7 @@ export default function PowiatyGamePage() {
                     ? t('powiatyPage.wonMessage')
                     : t('powiatyPage.lostMessage')}
                 </p>
-                 {(correctPowiat || guesses.find(g => g.answer)?.guess) && (
+                 {gameState.won && (correctPowiat || guesses.find(g => g.answer)?.guess) && (
                     <p className="text-base">{t('powiatyPage.answer')} <span className="font-bold">{correctPowiat?.nazwa || guesses.find(g => g.answer)?.guess}</span></p>
                  )}
               </div>
@@ -229,4 +216,3 @@ export default function PowiatyGamePage() {
     </div>
   );
 }
-

--- a/client/src/pages/USStatesGamePage.tsx
+++ b/client/src/pages/USStatesGamePage.tsx
@@ -1,7 +1,5 @@
 import { useEffect } from 'react';
 import { useUSStatesGameStore } from '../stores/gameStore';
-import { useAuthStore } from '../stores/authStore';
-import { useNavigate } from 'react-router-dom';
 import QuestionInput from '../components/QuestionInput';
 import History from '../components/History';
 import GuessInput from '../components/GuessInput';
@@ -23,25 +21,14 @@ export default function USStatesGamePage() {
     askQuestion, 
     makeGuess 
   } = useUSStatesGameStore();
-  const { isAuthenticated, isLoading: isAuthLoading } = useAuthStore();
   const { t } = useTranslation();
-  const navigate = useNavigate();
 
   useEffect(() => {
-    if (!isAuthLoading && !isAuthenticated) {
-      navigate('/login');
-    }
-  }, [isAuthenticated, isAuthLoading, navigate]);
+    fetchGameState();
+    fetchStates();
+  }, [fetchGameState, fetchStates]);
 
-
-  useEffect(() => {
-    if (isAuthenticated) {
-      fetchGameState();
-      fetchStates();
-    }
-  }, [isAuthenticated, fetchGameState, fetchStates]);
-
-  if (isAuthLoading || (!gameState && isLoading)) {
+  if (!gameState && isLoading) {
     return (
       <div className="flex justify-center items-center h-[60vh]">
         <Loader2 className="animate-spin text-blue-500" size={48} />
@@ -91,7 +78,7 @@ export default function USStatesGamePage() {
         <div className="w-full lg:w-3/4 flex flex-col p-3 md:p-4 gap-4 lg:overflow-y-auto custom-scrollbar">
             {/* Map */}
             <div className="h-[300px] md:h-[400px] lg:flex-1 lg:mb-16 min-h-[300px] shrink-0 bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden relative shadow-lg">
-                <USStatesMap correctStateName={correctState?.name} className="h-full" />
+                <USStatesMap correctStateName={gameState.won ? correctState?.name : undefined} className="h-full" />
             </div>
 
             {/* Game Over Message */}
@@ -105,7 +92,7 @@ export default function USStatesGamePage() {
                     ? t('usStatesPage.wonMessage')
                     : t('gamePage.lostMessage')}
                 </p>
-                 {(correctState || guesses.find(g => g.answer)?.guess) && (
+                 {gameState.won && (correctState || guesses.find(g => g.answer)?.guess) && (
                     <p className="text-sm md:text-base">{t('usStatesPage.answer')} <span className="font-bold">{correctState?.name || guesses.find(g => g.answer)?.guess}</span></p>
                  )}
               </div>
@@ -221,4 +208,3 @@ export default function USStatesGamePage() {
     </div>
   );
 }
-

--- a/client/src/pages/WojewodztwaGamePage.tsx
+++ b/client/src/pages/WojewodztwaGamePage.tsx
@@ -1,7 +1,5 @@
 import { useEffect } from 'react';
 import { useWojewodztwaGameStore } from '../stores/gameStore';
-import { useAuthStore } from '../stores/authStore';
-import { useNavigate } from 'react-router-dom';
 import QuestionInput from '../components/QuestionInput';
 import History from '../components/History';
 import GuessInput from '../components/GuessInput';
@@ -24,25 +22,14 @@ export default function WojewodztwaGamePage() {
     makeGuess
   } = useWojewodztwaGameStore();
 
-  const { isAuthenticated, isLoading: isAuthLoading } = useAuthStore();
   const { t } = useTranslation();
-  const navigate = useNavigate();
 
   useEffect(() => {
-    if (!isAuthLoading && !isAuthenticated) {
-      navigate('/login');
-    }
-  }, [isAuthenticated, isAuthLoading, navigate]);
+    fetchGameState();
+    fetchWojewodztwa();
+  }, [fetchGameState, fetchWojewodztwa]);
 
-
-  useEffect(() => {
-    if (isAuthenticated) {
-      fetchGameState();
-      fetchWojewodztwa();
-    }
-  }, [isAuthenticated, fetchGameState, fetchWojewodztwa]);
-
-  if (isAuthLoading || (!gameState && isLoading)) {
+  if (!gameState && isLoading) {
     return (
       <div className="flex justify-center items-center h-[60vh]">
         <Loader2 className="animate-spin text-blue-500" size={48} />
@@ -96,7 +83,7 @@ export default function WojewodztwaGamePage() {
             {/* Map */}
 
             <div className="h-[300px] md:h-[400px] lg:flex-1 lg:mb-16 min-h-[300px] shrink-0 bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden relative shadow-lg">
-                <WojewodztwaMap correctWojewodztwoName={correctWojewodztwo?.nazwa} className="h-full" />
+                <WojewodztwaMap correctWojewodztwoName={gameState.won ? correctWojewodztwo?.nazwa : undefined} className="h-full" />
             </div>
 
             {/* Game Over State */}
@@ -110,7 +97,7 @@ export default function WojewodztwaGamePage() {
                     ? t('wojewodztwaPage.wonMessage')
                     : t('wojewodztwaPage.lostMessage')}
                 </p>
-                 {(correctWojewodztwo || guesses.find(g => g.answer)?.guess) && (
+                 {gameState.won && (correctWojewodztwo || guesses.find(g => g.answer)?.guess) && (
                     <p className="text-base">{t('wojewodztwaPage.answer')} <span className="font-bold">{correctWojewodztwo?.nazwa || guesses.find(g => g.answer)?.guess}</span></p>
                  )}
               </div>
@@ -226,4 +213,3 @@ export default function WojewodztwaGamePage() {
     </div>
   );
 }
-

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -13,11 +13,15 @@ api.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response && error.response.status === 401) {
-      // Clear local storage and redirect to login
-      localStorage.removeItem('user');
-      if (window.location.pathname !== '/login') {
-        localStorage.setItem('session_expired', 'true');
-        window.location.href = '/login';
+      const requestUrl = error.config?.url || '';
+      const isGuestGameRequest = /^\/(countrydle|powiatdle|us_statedle|wojewodztwodle)\//.test(requestUrl);
+
+      if (!isGuestGameRequest) {
+        localStorage.removeItem('user');
+        if (window.location.pathname !== '/login') {
+          localStorage.setItem('session_expired', 'true');
+          window.location.href = '/login';
+        }
       }
     }
     return Promise.reject(error);
@@ -177,4 +181,3 @@ export const timeService = {
 };
 
 export default api;
-

--- a/docker-compose.test-db-only.yml
+++ b/docker-compose.test-db-only.yml
@@ -1,0 +1,17 @@
+services:
+  db_test:
+    image: pgvector/pgvector:pg17
+    container_name: countrydle_test_db
+    environment:
+      POSTGRES_DB: guess_country_test
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - ./postgres_test_data:/var/lib/postgresql/data
+    ports:
+      - "55432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d guess_country_test"]
+      interval: 5s
+      timeout: 5s
+      retries: 10

--- a/server/alembic/versions/7c0f0e9f6b34_allow_null_question_user_ids_for_guests.py
+++ b/server/alembic/versions/7c0f0e9f6b34_allow_null_question_user_ids_for_guests.py
@@ -1,0 +1,52 @@
+"""allow_null_question_user_ids_for_guests
+
+Revision ID: 7c0f0e9f6b34
+Revises: d8765268ed25
+Create Date: 2026-02-24 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "7c0f0e9f6b34"
+down_revision: Union[str, Sequence[str], None] = "d8765268ed25"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "countrydle_questions", "user_id", existing_type=sa.Integer(), nullable=True
+    )
+    op.alter_column(
+        "powiatdle_questions", "user_id", existing_type=sa.Integer(), nullable=True
+    )
+    op.alter_column(
+        "us_statedle_questions", "user_id", existing_type=sa.Integer(), nullable=True
+    )
+    op.alter_column(
+        "wojewodztwodle_questions", "user_id", existing_type=sa.Integer(), nullable=True
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "wojewodztwodle_questions",
+        "user_id",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )
+    op.alter_column(
+        "us_statedle_questions", "user_id", existing_type=sa.Integer(), nullable=False
+    )
+    op.alter_column(
+        "powiatdle_questions", "user_id", existing_type=sa.Integer(), nullable=False
+    )
+    op.alter_column(
+        "countrydle_questions", "user_id", existing_type=sa.Integer(), nullable=False
+    )

--- a/server/countrydle/utils.py
+++ b/server/countrydle/utils.py
@@ -126,7 +126,7 @@ User's Question: "asdfghjkl"
 async def ask_question(
     question: QuestionEnhanced,
     day_country: CountrydleDay,
-    user: User,
+    user: User | None,
     session: AsyncSession,
 ) -> QuestionCreate:
 
@@ -220,7 +220,7 @@ Country: Japan. Question: Has the country hosted the 2025 World Expo?
         raise
 
     question_create = QuestionCreate(
-        user_id=user.id,
+        user_id=user.id if user else None,
         day_id=day_country.id,
         original_question=question.original_question,
         valid=question.valid,

--- a/server/db/models/powiatdle.py
+++ b/server/db/models/powiatdle.py
@@ -28,7 +28,7 @@ class PowiatdleState(Base):
     __tablename__ = "powiatdle_states"
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"))
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     day_id = Column(Integer, ForeignKey("powiatdle_days.id"))
     remaining_questions = Column(Integer, nullable=False, default=15)
     remaining_guesses = Column(Integer, nullable=False, default=3)

--- a/server/db/models/question.py
+++ b/server/db/models/question.py
@@ -21,7 +21,7 @@ class CountrydleQuestion(Base):
     __tablename__ = "countrydle_questions"
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"))
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     day_id = Column(Integer, ForeignKey("countrydle_days.id"))
     context = Column(String)
     original_question = Column(String, nullable=False)

--- a/server/db/models/us_statedle.py
+++ b/server/db/models/us_statedle.py
@@ -27,7 +27,7 @@ class USStatedleState(Base):
     __tablename__ = "us_statedle_states"
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"))
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     day_id = Column(Integer, ForeignKey("us_statedle_days.id"))
     remaining_questions = Column(Integer, nullable=False, default=8)
     remaining_guesses = Column(Integer, nullable=False, default=3)

--- a/server/db/models/wojewodztwodle.py
+++ b/server/db/models/wojewodztwodle.py
@@ -27,7 +27,7 @@ class WojewodztwodleState(Base):
     __tablename__ = "wojewodztwodle_states"
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"))
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     day_id = Column(Integer, ForeignKey("wojewodztwodle_days.id"))
     remaining_questions = Column(Integer, nullable=False, default=5)
     remaining_guesses = Column(Integer, nullable=False, default=2)

--- a/server/db/repositories/us_statedle.py
+++ b/server/db/repositories/us_statedle.py
@@ -3,7 +3,12 @@ from sqlalchemy import select, func, and_, cast, Integer, desc
 from sqlalchemy.orm import joinedload
 from sqlalchemy.ext.asyncio import AsyncSession
 from db.models.us_state import USState
-from db.models.us_statedle import USStatedleDay, USStatedleState, USStatedleGuess, USStatedleQuestion
+from db.models.us_statedle import (
+    USStatedleDay,
+    USStatedleState,
+    USStatedleGuess,
+    USStatedleQuestion,
+)
 from db.models.user import User
 from schemas.us_statedle import USStateGuessCreate, USStateQuestionCreate
 from schemas.countrydle import LeaderboardEntry
@@ -23,9 +28,11 @@ class USStatedleDayRepository:
 
     async def generate_new_day_us_state(self) -> USStatedleDay:
         # Get a random us_state
-        result = await self.session.execute(select(USState).order_by(func.random()).limit(1))
+        result = await self.session.execute(
+            select(USState).order_by(func.random()).limit(1)
+        )
         us_state = result.scalar_one_or_none()
-        
+
         if not us_state:
             raise Exception("No US states found in database!")
 
@@ -37,6 +44,7 @@ class USStatedleDayRepository:
 
     async def get_history(self) -> List[USStatedleDay]:
         from datetime import date
+
         result = await self.session.execute(
             select(USStatedleDay)
             .options(joinedload(USStatedleDay.us_state))
@@ -50,23 +58,30 @@ class USStatedleStateRepository:
     def __init__(self, session: AsyncSession):
         self.session = session
 
-    async def get_state(self, user: User, day: USStatedleDay) -> Optional[USStatedleState]:
+    async def get_state(
+        self, user: User, day: USStatedleDay
+    ) -> Optional[USStatedleState]:
         result = await self.session.execute(
             select(USStatedleState).where(
                 and_(
-                    USStatedleState.user_id == user.id,
-                    USStatedleState.day_id == day.id
+                    USStatedleState.user_id == user.id, USStatedleState.day_id == day.id
                 )
             )
         )
         return result.scalar_one_or_none()
 
-    async def create_state(self, user: User, day: USStatedleDay, max_questions: int = 8, max_guesses: int = 3) -> USStatedleState:
+    async def create_state(
+        self,
+        user: User,
+        day: USStatedleDay,
+        max_questions: int = 8,
+        max_guesses: int = 3,
+    ) -> USStatedleState:
         new_state = USStatedleState(
-            user_id=user.id, 
+            user_id=user.id,
             day_id=day.id,
             remaining_questions=max_questions,
-            remaining_guesses=max_guesses
+            remaining_guesses=max_guesses,
         )
         self.session.add(new_state)
         await self.session.commit()
@@ -92,47 +107,48 @@ class USStatedleStateRepository:
                 User.id,
                 User.username,
                 func.coalesce(func.sum(USStatedleState.points), 0).label("points"),
-                func.coalesce(func.sum(cast(USStatedleState.won, Integer)), 0).label("wins"),
+                func.coalesce(func.sum(cast(USStatedleState.won, Integer)), 0).label(
+                    "wins"
+                ),
             )
             .join(User, User.id == USStatedleState.user_id)
             .where(
                 and_(
-                    User.username.not_like('test_%'),
-                    User.username.not_like('pytest_%'),
-                    User.username.not_like('guess_c_%'),
-                    User.username.not_like('ask_q_%')
+                    User.username.not_like("test_%"),
+                    User.username.not_like("pytest_%"),
+                    User.username.not_like("guess_c_%"),
+                    User.username.not_like("ask_q_%"),
                 )
             )
             .group_by(User.id, User.username)
             .order_by(desc("points"), desc("wins"))
         )
-        
+
         result = await self.session.execute(stmt)
-        
+
         return [
             LeaderboardEntry(
                 id=row.id,
                 username=row.username,
                 points=row.points,
                 wins=row.wins,
-                streak=0 # Streak not implemented yet for sub-games
+                streak=0,  # Streak not implemented yet for sub-games
             )
             for row in result.all()
         ]
 
     async def get_user_statistics(self, user: User) -> GameStatistics:
         # Calculate total points and wins
-        stmt = (
-            select(
-                func.coalesce(func.sum(USStatedleState.points), 0).label("points"),
-                func.coalesce(func.sum(cast(USStatedleState.won, Integer)), 0).label("wins"),
-                func.count(USStatedleState.id).label("games_played")
-            )
-            .where(USStatedleState.user_id == user.id)
-        )
+        stmt = select(
+            func.coalesce(func.sum(USStatedleState.points), 0).label("points"),
+            func.coalesce(func.sum(cast(USStatedleState.won, Integer)), 0).label(
+                "wins"
+            ),
+            func.count(USStatedleState.id).label("games_played"),
+        ).where(USStatedleState.user_id == user.id)
         result = await self.session.execute(stmt)
         row = result.first()
-        
+
         points = row.points if row else 0
         wins = row.wins if row else 0
         games_played = row.games_played if row else 0
@@ -141,20 +157,26 @@ class USStatedleStateRepository:
         history_stmt = (
             select(USStatedleState)
             .options(joinedload(USStatedleState.day).joinedload(USStatedleDay.us_state))
-            .where(and_(USStatedleState.user_id == user.id, USStatedleState.is_game_over == True))
+            .where(
+                and_(
+                    USStatedleState.user_id == user.id,
+                    USStatedleState.is_game_over == True,
+                )
+            )
             .order_by(USStatedleState.id.desc())
         )
         history_result = await self.session.execute(history_stmt)
         history_states = history_result.scalars().all()
 
         from datetime import date
+
         history_entries = [
             GameHistoryEntry(
                 date=str(state.day.date),
                 won=state.won,
                 points=state.points,
                 attempts=state.guesses_made,
-                target_name=state.day.us_state.name if state.day.date < date.today() else "???"
+                target_name=state.day.us_state.name if state.won else "???",
             )
             for state in history_states
         ]
@@ -163,8 +185,8 @@ class USStatedleStateRepository:
             points=points,
             wins=wins,
             games_played=games_played,
-            streak=0, # TODO: Implement streak
-            history=history_entries
+            streak=0,  # TODO: Implement streak
+            history=history_entries,
         )
 
 
@@ -179,14 +201,17 @@ class USStatedleGuessRepository:
         await self.session.refresh(new_guess)
         return new_guess
 
-    async def get_user_day_guesses(self, user: User, day: USStatedleDay) -> List[USStatedleGuess]:
+    async def get_user_day_guesses(
+        self, user: User, day: USStatedleDay
+    ) -> List[USStatedleGuess]:
         result = await self.session.execute(
-            select(USStatedleGuess).where(
+            select(USStatedleGuess)
+            .where(
                 and_(
-                    USStatedleGuess.user_id == user.id,
-                    USStatedleGuess.day_id == day.id
+                    USStatedleGuess.user_id == user.id, USStatedleGuess.day_id == day.id
                 )
-            ).order_by(USStatedleGuess.guessed_at.asc())
+            )
+            .order_by(USStatedleGuess.guessed_at.asc())
         )
         return list(result.scalars().all())
 
@@ -195,20 +220,26 @@ class USStatedleQuestionRepository:
     def __init__(self, session: AsyncSession):
         self.session = session
 
-    async def create_question(self, question_create: USStateQuestionCreate) -> USStatedleQuestion:
+    async def create_question(
+        self, question_create: USStateQuestionCreate
+    ) -> USStatedleQuestion:
         new_question = USStatedleQuestion(**question_create.model_dump())
         self.session.add(new_question)
         await self.session.commit()
         await self.session.refresh(new_question)
         return new_question
 
-    async def get_user_day_questions(self, user: User, day: USStatedleDay) -> List[USStatedleQuestion]:
+    async def get_user_day_questions(
+        self, user: User, day: USStatedleDay
+    ) -> List[USStatedleQuestion]:
         result = await self.session.execute(
-            select(USStatedleQuestion).where(
+            select(USStatedleQuestion)
+            .where(
                 and_(
                     USStatedleQuestion.user_id == user.id,
-                    USStatedleQuestion.day_id == day.id
+                    USStatedleQuestion.day_id == day.id,
                 )
-            ).order_by(USStatedleQuestion.asked_at.asc())
+            )
+            .order_by(USStatedleQuestion.asked_at.asc())
         )
         return list(result.scalars().all())

--- a/server/powiatdle/utils.py
+++ b/server/powiatdle/utils.py
@@ -98,7 +98,7 @@ Wyjście:
 async def ask_question(
     question: PowiatQuestionEnhanced,
     day_powiat: PowiatdleDay,
-    user: User,
+    user: User | None,
     session: AsyncSession,
 ) -> PowiatQuestionCreate:
 
@@ -160,7 +160,7 @@ Odpowiedz w formacie JSON i niczym więcej. Użyj określonego formatu:
         raise
 
     question_create = PowiatQuestionCreate(
-        user_id=user.id,
+        user_id=user.id if user else None,
         day_id=day_powiat.id,
         original_question=question.original_question,
         valid=question.valid,

--- a/server/schemas/countrydle.py
+++ b/server/schemas/countrydle.py
@@ -11,7 +11,6 @@ class QuestionBase(BaseModel):
     question: str = Field(max_length=100)
 
 
-
 class QuestionEnhanced(BaseModel):
     original_question: str
     question: str | None
@@ -23,7 +22,7 @@ class QuestionEnhanced(BaseModel):
 
 class QuestionCreate(QuestionEnhanced):
     answer: bool | None
-    user_id: int
+    user_id: int | None
     day_id: int
     context: str | None
 
@@ -36,7 +35,7 @@ class QuestionDisplay(BaseModel):
     question: str | None
     valid: bool
     answer: bool | None
-    user_id: int
+    user_id: int | None
     day_id: int
     asked_at: datetime
 
@@ -54,7 +53,7 @@ class InvalidQuestionDisplay(BaseModel):
     original_question: str
     valid: bool
     answer: bool | None
-    user_id: int
+    user_id: int | None
     day_id: int
     asked_at: datetime
 

--- a/server/schemas/powiatdle.py
+++ b/server/schemas/powiatdle.py
@@ -51,9 +51,8 @@ class PowiatQuestionBase(BaseModel):
     question: str = Field(max_length=100)
 
 
-
 class PowiatQuestionCreate(BaseModel):
-    user_id: int
+    user_id: Optional[int]
     day_id: int
     original_question: str
     question: Optional[str]
@@ -101,4 +100,3 @@ class DayPowiatDisplay(BaseModel):
     date: date
 
     model_config = ConfigDict(from_attributes=True)
-

--- a/server/schemas/us_statedle.py
+++ b/server/schemas/us_statedle.py
@@ -52,9 +52,8 @@ class USStateQuestionBase(BaseModel):
     question: str = Field(max_length=100)
 
 
-
 class USStateQuestionCreate(BaseModel):
-    user_id: int
+    user_id: Optional[int]
     day_id: int
     original_question: str
     question: Optional[str]
@@ -102,4 +101,3 @@ class DayUSStateDisplay(BaseModel):
     date: date
 
     model_config = ConfigDict(from_attributes=True)
-

--- a/server/schemas/wojewodztwodle.py
+++ b/server/schemas/wojewodztwodle.py
@@ -51,9 +51,8 @@ class WojewodztwoQuestionBase(BaseModel):
     question: str = Field(max_length=100)
 
 
-
 class WojewodztwoQuestionCreate(BaseModel):
-    user_id: int
+    user_id: Optional[int]
     day_id: int
     original_question: str
     question: Optional[str]
@@ -101,4 +100,3 @@ class DayWojewodztwoDisplay(BaseModel):
     date: date
 
     model_config = ConfigDict(from_attributes=True)
-

--- a/server/tests/test_game.py
+++ b/server/tests/test_game.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 from unittest.mock import patch, AsyncMock
 
+
 @pytest.mark.anyio
 async def test_get_countries(auth_client):
     response = await auth_client.get("/countrydle/countries")
@@ -12,21 +13,36 @@ async def test_get_countries(auth_client):
     assert "id" in data[0]
     assert "name" in data[0]
 
+
 @pytest.mark.anyio
 async def test_get_game_state(auth_client):
     from unittest.mock import MagicMock
-    with patch("db.repositories.countrydle.CountrydleRepository.get_today_country", new_callable=AsyncMock) as mock_get_today, \
-         patch("db.repositories.countrydle.CountrydleStateRepository.get_state", new_callable=AsyncMock) as mock_get_state, \
-         patch("db.repositories.guess.CountrydleGuessRepository.get_user_day_guesses", new_callable=AsyncMock) as mock_get_guesses, \
-         patch("db.repositories.question.CountrydleQuestionsRepository.get_user_day_questions", new_callable=AsyncMock) as mock_get_questions:
-        
+
+    with (
+        patch(
+            "db.repositories.countrydle.CountrydleRepository.get_today_country",
+            new_callable=AsyncMock,
+        ) as mock_get_today,
+        patch(
+            "db.repositories.countrydle.CountrydleStateRepository.get_state",
+            new_callable=AsyncMock,
+        ) as mock_get_state,
+        patch(
+            "db.repositories.guess.CountrydleGuessRepository.get_user_day_guesses",
+            new_callable=AsyncMock,
+        ) as mock_get_guesses,
+        patch(
+            "db.repositories.question.CountrydleQuestionsRepository.get_user_day_questions",
+            new_callable=AsyncMock,
+        ) as mock_get_questions,
+    ):
         # Mock Day
         mock_day = MagicMock()
         mock_day.id = 1
         mock_day.country_id = 100
         mock_day.date = "2023-01-01"
         mock_get_today.return_value = mock_day
-        
+
         # Mock State
         mock_state = MagicMock()
         mock_state.id = 1
@@ -40,7 +56,7 @@ async def test_get_game_state(auth_client):
         mock_state.won = False
         mock_state.points = 0
         mock_get_state.return_value = mock_state
-        
+
         mock_get_guesses.return_value = []
         mock_get_questions.return_value = []
 
@@ -50,18 +66,34 @@ async def test_get_game_state(auth_client):
         assert "state" in data
         assert "remaining_guesses" in data["state"]
 
+
 @pytest.mark.anyio
 async def test_make_guess_correct(async_client):
     # Mock dependencies to test logic without DB
-    with patch("db.repositories.countrydle.CountrydleRepository.get_today_country", new_callable=AsyncMock) as mock_get_today, \
-         patch("db.repositories.countrydle.CountrydleStateRepository.get_player_countrydle_state", new_callable=AsyncMock) as mock_get_state, \
-         patch("db.repositories.country.CountryRepository.get", new_callable=AsyncMock) as mock_get_country, \
-         patch("db.repositories.guess.CountrydleGuessRepository.add_guess", new_callable=AsyncMock) as mock_add_guess, \
-         patch("db.repositories.countrydle.CountrydleStateRepository.guess_made", new_callable=AsyncMock) as mock_guess_made:
-
+    with (
+        patch(
+            "db.repositories.countrydle.CountrydleRepository.get_today_country",
+            new_callable=AsyncMock,
+        ) as mock_get_today,
+        patch(
+            "db.repositories.countrydle.CountrydleStateRepository.get_player_countrydle_state",
+            new_callable=AsyncMock,
+        ) as mock_get_state,
+        patch(
+            "db.repositories.country.CountryRepository.get", new_callable=AsyncMock
+        ) as mock_get_country,
+        patch(
+            "db.repositories.guess.CountrydleGuessRepository.add_guess",
+            new_callable=AsyncMock,
+        ) as mock_add_guess,
+        patch(
+            "db.repositories.countrydle.CountrydleStateRepository.guess_made",
+            new_callable=AsyncMock,
+        ) as mock_guess_made,
+    ):
         # Setup mocks
         from unittest.mock import MagicMock
-        
+
         # Mock DayCountry
         mock_day = MagicMock()
         mock_day.id = 1
@@ -92,26 +124,27 @@ async def test_make_guess_correct(async_client):
         mock_add_guess.return_value = mock_guess_result
 
     from app import app
-    from users.utils import get_current_user
+    from users.utils import get_current_or_guest_user
     from db.models import User
-    
+
     async def mock_get_current_user():
         user = MagicMock(spec=User)
         user.id = 1
         user.username = "test_user"
         return user
-        
-    app.dependency_overrides[get_current_user] = mock_get_current_user
-    
+
+    app.dependency_overrides[get_current_or_guest_user] = mock_get_current_user
+
     try:
         pass
     finally:
         app.dependency_overrides = {}
 
+
 @pytest.mark.anyio
 async def test_make_guess_correct_mocked(async_client):
     from app import app
-    from users.utils import get_current_user
+    from users.utils import get_current_or_guest_user
     from db.models import User
     from unittest.mock import MagicMock
 
@@ -123,16 +156,31 @@ async def test_make_guess_correct_mocked(async_client):
         user.email = "test@example.com"
         user.verified = True
         return user
-    
-    app.dependency_overrides[get_current_user] = mock_get_current_user
+
+    app.dependency_overrides[get_current_or_guest_user] = mock_get_current_user
 
     try:
-        with patch("db.repositories.countrydle.CountrydleRepository.get_today_country", new_callable=AsyncMock) as mock_get_today, \
-             patch("db.repositories.countrydle.CountrydleStateRepository.get_player_countrydle_state", new_callable=AsyncMock) as mock_get_state, \
-             patch("db.repositories.country.CountryRepository.get", new_callable=AsyncMock) as mock_get_country, \
-             patch("db.repositories.guess.CountrydleGuessRepository.add_guess", new_callable=AsyncMock) as mock_add_guess, \
-             patch("db.repositories.countrydle.CountrydleStateRepository.guess_made", new_callable=AsyncMock) as mock_guess_made:
-
+        with (
+            patch(
+                "db.repositories.countrydle.CountrydleRepository.get_today_country",
+                new_callable=AsyncMock,
+            ) as mock_get_today,
+            patch(
+                "db.repositories.countrydle.CountrydleStateRepository.get_player_countrydle_state",
+                new_callable=AsyncMock,
+            ) as mock_get_state,
+            patch(
+                "db.repositories.country.CountryRepository.get", new_callable=AsyncMock
+            ) as mock_get_country,
+            patch(
+                "db.repositories.guess.CountrydleGuessRepository.add_guess",
+                new_callable=AsyncMock,
+            ) as mock_add_guess,
+            patch(
+                "db.repositories.countrydle.CountrydleStateRepository.guess_made",
+                new_callable=AsyncMock,
+            ) as mock_guess_made,
+        ):
             # Mock DayCountry
             mock_day = MagicMock()
             mock_day.id = 1
@@ -164,15 +212,15 @@ async def test_make_guess_correct_mocked(async_client):
             # Test Data
             guess_data = {
                 "guess": "Poland",
-                "country_id": 100 # Correct ID
+                "country_id": 100,  # Correct ID
             }
-            
+
             response = await async_client.post("/countrydle/guess", json=guess_data)
-            
+
             assert response.status_code == 200
             data = response.json()
             assert data["answer"] is True
-            
+
             # Verify add_guess was called with correct data
             args, _ = mock_add_guess.call_args
             guess_create_arg = args[0]
@@ -182,46 +230,56 @@ async def test_make_guess_correct_mocked(async_client):
     finally:
         app.dependency_overrides = {}
 
+
 @pytest.mark.anyio
 async def test_ask_question_too_long(auth_client):
     long_question = "a" * 51
     question_data = {"question": long_question}
     response = await auth_client.post("/countrydle/question", json=question_data)
-    assert response.status_code == 422 # Unprocessable Entity for validation error
+    assert response.status_code == 422  # Unprocessable Entity for validation error
     # Mocking the external dependencies for asking a question
     # We need to mock:
     # 1. gutils.enhance_question (LLM)
     # 2. gutils.ask_question (LLM + Qdrant)
     # 3. add_question_to_qdrant (Qdrant)
-    
-    with patch("countrydle.utils.enhance_question", new_callable=AsyncMock) as mock_enhance, \
-         patch("countrydle.utils.ask_question", new_callable=AsyncMock) as mock_ask, \
-         patch("countrydle.__init__.add_question_to_qdrant", new_callable=AsyncMock) as mock_add_qdrant, \
-         patch("db.repositories.question.CountrydleQuestionsRepository.create_question", new_callable=AsyncMock) as mock_create_question:
-        
+
+    with (
+        patch(
+            "countrydle.utils.enhance_question", new_callable=AsyncMock
+        ) as mock_enhance,
+        patch("countrydle.utils.ask_question", new_callable=AsyncMock) as mock_ask,
+        patch(
+            "countrydle.__init__.add_question_to_qdrant", new_callable=AsyncMock
+        ) as mock_add_qdrant,
+        patch(
+            "db.repositories.question.CountrydleQuestionsRepository.create_question",
+            new_callable=AsyncMock,
+        ) as mock_create_question,
+    ):
         # Setup mocks
         mock_enhance.return_value.valid = True
         mock_enhance.return_value.original_question = "Is it in Europe?"
         mock_enhance.return_value.question = "Is the country located in Europe?"
         mock_enhance.return_value.explanation = "Explanation"
-        
+
         from schemas.countrydle import QuestionCreate, QuestionDisplay
         from datetime import datetime
-        
+
         mock_q_create = QuestionCreate(
             original_question="Is it in Europe?",
             question="Is the country located in Europe?",
             valid=True,
             explanation="Yes",
             answer=True,
-            user_id=1, 
-            day_id=1, # This ID doesn't matter if we mock the create_question
-            context="Context"
+            user_id=1,
+            day_id=1,  # This ID doesn't matter if we mock the create_question
+            context="Context",
         )
         mock_ask.return_value = (mock_q_create, [0.1] * 1536)
-        
+
         # Mock the create_question method return value
         from unittest.mock import MagicMock
+
         mock_question_db_obj = MagicMock()
         mock_question_db_obj.id = 123
         mock_question_db_obj.original_question = "Is it in Europe?"
@@ -232,12 +290,12 @@ async def test_ask_question_too_long(auth_client):
         mock_question_db_obj.day_id = 1
         mock_question_db_obj.asked_at = datetime.now()
         mock_question_db_obj.explanation = "Explanation"
-        
+
         mock_create_question.return_value = mock_question_db_obj
-        
+
         question_data = {"question": "Is it in Europe?"}
         response = await auth_client.post("/countrydle/question", json=question_data)
-        
+
         assert response.status_code == 200
         data = response.json()
         assert data["valid"] is True

--- a/server/tests/test_new_games.py
+++ b/server/tests/test_new_games.py
@@ -1,8 +1,9 @@
 import pytest
 from unittest.mock import patch, AsyncMock, MagicMock
 from db.models import User
-from users.utils import get_current_user
+from users.utils import get_current_or_guest_user
 from app import app
+
 
 @pytest.fixture
 async def mock_user_override():
@@ -13,25 +14,39 @@ async def mock_user_override():
         user.email = "test@example.com"
         user.verified = True
         return user
-    
-    app.dependency_overrides[get_current_user] = mock_get_current_user
+
+    app.dependency_overrides[get_current_or_guest_user] = mock_get_current_user
     yield
     app.dependency_overrides = {}
 
+
 @pytest.mark.anyio
 async def test_us_statedle_state(async_client, mock_user_override):
-    with patch("db.repositories.us_statedle.USStatedleDayRepository.get_today_us_state", new_callable=AsyncMock) as mock_get_today, \
-         patch("db.repositories.us_statedle.USStatedleStateRepository.get_state", new_callable=AsyncMock) as mock_get_state, \
-         patch("db.repositories.us_statedle.USStatedleGuessRepository.get_user_day_guesses", new_callable=AsyncMock) as mock_get_guesses, \
-         patch("db.repositories.us_statedle.USStatedleQuestionRepository.get_user_day_questions", new_callable=AsyncMock) as mock_get_questions:
-        
+    with (
+        patch(
+            "db.repositories.us_statedle.USStatedleDayRepository.get_today_us_state",
+            new_callable=AsyncMock,
+        ) as mock_get_today,
+        patch(
+            "db.repositories.us_statedle.USStatedleStateRepository.get_state",
+            new_callable=AsyncMock,
+        ) as mock_get_state,
+        patch(
+            "db.repositories.us_statedle.USStatedleGuessRepository.get_user_day_guesses",
+            new_callable=AsyncMock,
+        ) as mock_get_guesses,
+        patch(
+            "db.repositories.us_statedle.USStatedleQuestionRepository.get_user_day_questions",
+            new_callable=AsyncMock,
+        ) as mock_get_questions,
+    ):
         # Mock Day
         mock_day = MagicMock()
         mock_day.id = 1
         mock_day.us_state_id = 10
         mock_day.date = "2023-01-01"
         mock_get_today.return_value = mock_day
-        
+
         # Mock State
         mock_state = MagicMock()
         mock_state.id = 1
@@ -45,30 +60,44 @@ async def test_us_statedle_state(async_client, mock_user_override):
         mock_state.won = False
         mock_state.points = 0
         mock_get_state.return_value = mock_state
-        
+
         mock_get_guesses.return_value = []
         mock_get_questions.return_value = []
-        
+
         response = await async_client.get("/us_statedle/state")
         assert response.status_code == 200
         data = response.json()
         assert data["state"]["remaining_questions"] == 10
         assert data["state"]["remaining_guesses"] == 3
 
+
 @pytest.mark.anyio
 async def test_wojewodztwodle_state(async_client, mock_user_override):
-    with patch("db.repositories.wojewodztwodle.WojewodztwodleDayRepository.get_today_wojewodztwo", new_callable=AsyncMock) as mock_get_today, \
-         patch("db.repositories.wojewodztwodle.WojewodztwodleStateRepository.get_state", new_callable=AsyncMock) as mock_get_state, \
-         patch("db.repositories.wojewodztwodle.WojewodztwodleGuessRepository.get_user_day_guesses", new_callable=AsyncMock) as mock_get_guesses, \
-         patch("db.repositories.wojewodztwodle.WojewodztwodleQuestionRepository.get_user_day_questions", new_callable=AsyncMock) as mock_get_questions:
-        
+    with (
+        patch(
+            "db.repositories.wojewodztwodle.WojewodztwodleDayRepository.get_today_wojewodztwo",
+            new_callable=AsyncMock,
+        ) as mock_get_today,
+        patch(
+            "db.repositories.wojewodztwodle.WojewodztwodleStateRepository.get_state",
+            new_callable=AsyncMock,
+        ) as mock_get_state,
+        patch(
+            "db.repositories.wojewodztwodle.WojewodztwodleGuessRepository.get_user_day_guesses",
+            new_callable=AsyncMock,
+        ) as mock_get_guesses,
+        patch(
+            "db.repositories.wojewodztwodle.WojewodztwodleQuestionRepository.get_user_day_questions",
+            new_callable=AsyncMock,
+        ) as mock_get_questions,
+    ):
         # Mock Day
         mock_day = MagicMock()
         mock_day.id = 1
         mock_day.wojewodztwo_id = 5
         mock_day.date = "2023-01-01"
         mock_get_today.return_value = mock_day
-        
+
         # Mock State
         mock_state = MagicMock()
         mock_state.id = 1
@@ -82,29 +111,43 @@ async def test_wojewodztwodle_state(async_client, mock_user_override):
         mock_state.won = False
         mock_state.points = 0
         mock_get_state.return_value = mock_state
-        
+
         mock_get_guesses.return_value = []
         mock_get_questions.return_value = []
-        
+
         response = await async_client.get("/wojewodztwodle/state")
         assert response.status_code == 200
         data = response.json()
         assert data["state"]["remaining_questions"] == 10
         assert data["state"]["remaining_guesses"] == 3
 
+
 @pytest.mark.anyio
 async def test_us_statedle_guess_correct(async_client, mock_user_override):
-    with patch("db.repositories.us_statedle.USStatedleDayRepository.get_today_us_state", new_callable=AsyncMock) as mock_get_today, \
-         patch("db.repositories.us_statedle.USStatedleStateRepository.get_state", new_callable=AsyncMock) as mock_get_state, \
-         patch("db.repositories.us_statedle.USStatedleGuessRepository.add_guess", new_callable=AsyncMock) as mock_add_guess, \
-         patch("db.repositories.us_statedle.USStatedleStateRepository.update_state", new_callable=AsyncMock) as mock_update_state:
-        
+    with (
+        patch(
+            "db.repositories.us_statedle.USStatedleDayRepository.get_today_us_state",
+            new_callable=AsyncMock,
+        ) as mock_get_today,
+        patch(
+            "db.repositories.us_statedle.USStatedleStateRepository.get_state",
+            new_callable=AsyncMock,
+        ) as mock_get_state,
+        patch(
+            "db.repositories.us_statedle.USStatedleGuessRepository.add_guess",
+            new_callable=AsyncMock,
+        ) as mock_add_guess,
+        patch(
+            "db.repositories.us_statedle.USStatedleStateRepository.update_state",
+            new_callable=AsyncMock,
+        ) as mock_update_state,
+    ):
         # Mock Day
         mock_day = MagicMock()
         mock_day.id = 1
         mock_day.us_state_id = 10
         mock_get_today.return_value = mock_day
-        
+
         # Mock State
         mock_state = MagicMock()
         mock_state.remaining_guesses = 3
@@ -113,7 +156,7 @@ async def test_us_statedle_guess_correct(async_client, mock_user_override):
         mock_state.won = False
         mock_state.is_game_over = False
         mock_get_state.return_value = mock_state
-        
+
         # Mock Guess Result
         mock_guess_result = MagicMock()
         mock_guess_result.id = 1
@@ -121,33 +164,45 @@ async def test_us_statedle_guess_correct(async_client, mock_user_override):
         mock_guess_result.us_state_id = 10
         mock_guess_result.answer = True
         from datetime import datetime
+
         mock_guess_result.guessed_at = datetime.now()
         mock_add_guess.return_value = mock_guess_result
-        
-        guess_data = {
-            "guess": "California",
-            "us_state_id": 10
-        }
-        
+
+        guess_data = {"guess": "California", "us_state_id": 10}
+
         response = await async_client.post("/us_statedle/guess", json=guess_data)
         assert response.status_code == 200
         data = response.json()
         assert data["answer"] is True
         assert mock_update_state.called
 
+
 @pytest.mark.anyio
 async def test_wojewodztwodle_guess_correct(async_client, mock_user_override):
-    with patch("db.repositories.wojewodztwodle.WojewodztwodleDayRepository.get_today_wojewodztwo", new_callable=AsyncMock) as mock_get_today, \
-         patch("db.repositories.wojewodztwodle.WojewodztwodleStateRepository.get_state", new_callable=AsyncMock) as mock_get_state, \
-         patch("db.repositories.wojewodztwodle.WojewodztwodleGuessRepository.add_guess", new_callable=AsyncMock) as mock_add_guess, \
-         patch("db.repositories.wojewodztwodle.WojewodztwodleStateRepository.update_state", new_callable=AsyncMock) as mock_update_state:
-        
+    with (
+        patch(
+            "db.repositories.wojewodztwodle.WojewodztwodleDayRepository.get_today_wojewodztwo",
+            new_callable=AsyncMock,
+        ) as mock_get_today,
+        patch(
+            "db.repositories.wojewodztwodle.WojewodztwodleStateRepository.get_state",
+            new_callable=AsyncMock,
+        ) as mock_get_state,
+        patch(
+            "db.repositories.wojewodztwodle.WojewodztwodleGuessRepository.add_guess",
+            new_callable=AsyncMock,
+        ) as mock_add_guess,
+        patch(
+            "db.repositories.wojewodztwodle.WojewodztwodleStateRepository.update_state",
+            new_callable=AsyncMock,
+        ) as mock_update_state,
+    ):
         # Mock Day
         mock_day = MagicMock()
         mock_day.id = 1
         mock_day.wojewodztwo_id = 5
         mock_get_today.return_value = mock_day
-        
+
         # Mock State
         mock_state = MagicMock()
         mock_state.remaining_guesses = 3
@@ -156,7 +211,7 @@ async def test_wojewodztwodle_guess_correct(async_client, mock_user_override):
         mock_state.won = False
         mock_state.is_game_over = False
         mock_get_state.return_value = mock_state
-        
+
         # Mock Guess Result
         mock_guess_result = MagicMock()
         mock_guess_result.id = 1
@@ -164,14 +219,12 @@ async def test_wojewodztwodle_guess_correct(async_client, mock_user_override):
         mock_guess_result.wojewodztwo_id = 5
         mock_guess_result.answer = True
         from datetime import datetime
+
         mock_guess_result.guessed_at = datetime.now()
         mock_add_guess.return_value = mock_guess_result
-        
-        guess_data = {
-            "guess": "Małopolskie",
-            "wojewodztwo_id": 5
-        }
-        
+
+        guess_data = {"guess": "Małopolskie", "wojewodztwo_id": 5}
+
         response = await async_client.post("/wojewodztwodle/guess", json=guess_data)
         assert response.status_code == 200
         data = response.json()

--- a/server/us_statedle/utils.py
+++ b/server/us_statedle/utils.py
@@ -120,7 +120,7 @@ Output:
 async def ask_question(
     question: USStateQuestionEnhanced,
     day_state: USStatedleDay,
-    user: User,
+    user: User | None,
     session: AsyncSession,
 ) -> USStateQuestionCreate:
 
@@ -181,7 +181,7 @@ Answer with JSON format and nothing else. Use the specific format:
         raise
 
     question_create = USStateQuestionCreate(
-        user_id=user.id,
+        user_id=user.id if user else None,
         day_id=day_state.id,
         original_question=question.original_question,
         valid=question.valid,


### PR DESCRIPTION
## Summary
- add guest-mode support for all game routes by introducing guest identity handling and allowing gameplay without account login
- prevent target word/entity leakage by returning and rendering the correct answer only when the player has won (including after daily rotation)
- allow guest question rows with nullable `user_id` via model/schema updates and a dedicated Alembic migration
- include a dedicated compose setup for a local test Postgres instance on port `55432`

## Validation
- `npm run build` (client) passes
- `alembic upgrade head` against test DB (`postgresql+asyncpg://postgres:postgres@localhost:55432/guess_country_test`) passes
- `pytest -q` with required env vars: `16 passed, 2 failed` (remaining failures depend on seeded country data in test DB)